### PR TITLE
Update server.js

### DIFF
--- a/src/monads/server.js
+++ b/src/monads/server.js
@@ -39,7 +39,7 @@ const Express = config => async specs => {
             RegisterOpenAPIValidator(config)(spec)(express)
             // Endpoint execution
             const expRegEndpoint = spec => path => method => express => {
-                const operationd = spec.paths[path][method].operationId
+                const operationid = spec.paths[path][method].operationId
 
                 const Exec = req => res => async func => load((func))(req, res)
 


### PR DESCRIPTION
operationid miss-spelled. 

Gateway was crashing: 

2022-04-13T02:01:27.410+05:30	Loading dir /usr/src/app/rest

2022-04-13T02:01:27.411+05:30	Loading /usr/src/app/rest/substance.yaml

2022-04-13T02:01:27.497+05:30	Registering middleware...............

2022-04-13T02:01:27.661+05:30	[ERROR] : Gateway crashed : ReferenceError: operationid is not defined